### PR TITLE
change the zone of  local related  formatter  from utc to  default zone

### DIFF
--- a/src/main/kotlin/io/github/alexbroadbent/tsgen/config/TimestampFormat.kt
+++ b/src/main/kotlin/io/github/alexbroadbent/tsgen/config/TimestampFormat.kt
@@ -1,5 +1,6 @@
 package io.github.alexbroadbent.tsgen.config
 
+import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.util.Locale
@@ -15,9 +16,9 @@ object TimestampFormatMap {
 
     private val map: Map<TimestampFormatTitle, DateTimeFormatter> = mapOf(
         TimestampFormatTitle.ISO_8601 to DateTimeFormatter.ISO_DATE_TIME.addLocaleAndZone(),
-        TimestampFormatTitle.ISO_LOCAL_DATE to DateTimeFormatter.ISO_LOCAL_DATE.addLocaleAndZone(),
-        TimestampFormatTitle.ISO_LOCAL_TIME to DateTimeFormatter.ISO_LOCAL_TIME.addLocaleAndZone(),
-        TimestampFormatTitle.ISO_LOCAL_DATE_TIME to DateTimeFormatter.ISO_LOCAL_DATE_TIME.addLocaleAndZone(),
+        TimestampFormatTitle.ISO_LOCAL_DATE to DateTimeFormatter.ISO_LOCAL_DATE.addLocaleAndDefaultZone(),
+        TimestampFormatTitle.ISO_LOCAL_TIME to DateTimeFormatter.ISO_LOCAL_TIME.addLocaleAndDefaultZone(),
+        TimestampFormatTitle.ISO_LOCAL_DATE_TIME to DateTimeFormatter.ISO_LOCAL_DATE_TIME.addLocaleAndDefaultZone(),
         TimestampFormatTitle.ISO_INSTANT to DateTimeFormatter.ISO_INSTANT.addLocaleAndZone(),
         TimestampFormatTitle.RFC_1123_DATE_TIME to DateTimeFormatter.ISO_INSTANT.addLocaleAndZone(),
         TimestampFormatTitle.ISO_ZONED_DATE_TIME to DateTimeFormatter.ISO_ZONED_DATE_TIME.addLocaleAndZone()
@@ -28,6 +29,7 @@ object TimestampFormatMap {
 }
 
 private fun DateTimeFormatter.addLocaleAndZone() = this.withLocale(Locale.UK).withZone(ZoneOffset.UTC)
+private fun DateTimeFormatter.addLocaleAndDefaultZone() = this.withLocale(Locale.UK).withZone(ZoneId.systemDefault())
 
 enum class TimestampFormatTitle(val title: String) {
     ISO_8601("ISO 8601"),

--- a/src/test/kotlin/io/github/alexbroadbent/tsgen/TimestampFormatSpec.kt
+++ b/src/test/kotlin/io/github/alexbroadbent/tsgen/TimestampFormatSpec.kt
@@ -7,6 +7,7 @@ import java.time.Instant
 import java.time.Month
 import java.time.ZoneOffset
 import java.time.ZonedDateTime
+import java.util.*
 
 class TimestampFormatSpec : ShouldSpec() {
 
@@ -15,6 +16,7 @@ class TimestampFormatSpec : ShouldSpec() {
     private val generator = TimestampGenerator
 
     init {
+        TimeZone.setDefault(TimeZone.getTimeZone("GMT+7:00"))
         "Check formatting" {
             should("cover ISO 8601 format") {
                 generate(TimestampFormatTitle.ISO_8601) shouldBe "2019-03-18T10:30:20.001234567Z"
@@ -26,10 +28,10 @@ class TimestampFormatSpec : ShouldSpec() {
                 generate(TimestampFormatTitle.ISO_LOCAL_DATE) shouldBe "2019-03-18"
             }
             should("cover ISO Local Time format") {
-                generate(TimestampFormatTitle.ISO_LOCAL_TIME) shouldBe "10:30:20.001234567"
+                generate(TimestampFormatTitle.ISO_LOCAL_TIME) shouldBe "17:30:20.001234567"
             }
             should("cover ISO Local DateTime format") {
-                generate(TimestampFormatTitle.ISO_LOCAL_DATE_TIME) shouldBe "2019-03-18T10:30:20.001234567"
+                generate(TimestampFormatTitle.ISO_LOCAL_DATE_TIME) shouldBe "2019-03-18T17:30:20.001234567"
             }
             should("cover ISO Zoned Date Time format") {
                 generate(TimestampFormatTitle.ISO_ZONED_DATE_TIME) shouldBe "2019-03-18T10:30:20.001234567Z"


### PR DESCRIPTION
Hello, I am a plugin user.

When using local* formatting, can I use the system default time zone instead of gmt time?