### PR TITLE
Fix persisting settings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,8 +43,7 @@ tasks {
     }
 
     patchPluginXml {
-        version.set("1.0.1")
-        sinceBuild.set("143")
+        version.set("1.1.0")
         sinceBuild.set("201")
         untilBuild.set("")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 }
 
 group = "io.github.alexbroadbent"
-version = "1.0.1"
+version = "1.1.0"
 
 repositories {
     mavenCentral()
@@ -45,6 +45,7 @@ tasks {
     patchPluginXml {
         version.set("1.0.1")
         sinceBuild.set("143")
+        sinceBuild.set("201")
         untilBuild.set("")
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=io.github.alexbroadbent.tsgen
 description=Timestamp Generator
-version=1.0.1
+version=1.1.0

--- a/src/main/kotlin/io/github/alexbroadbent/tsgen/config/SettingsForm.kt
+++ b/src/main/kotlin/io/github/alexbroadbent/tsgen/config/SettingsForm.kt
@@ -59,5 +59,5 @@ class SettingsForm {
         )
 
     val isModified: Boolean
-        get() = getSelectedFormat() != settings.format
+        get() = getSelectedFormat().title != settings.format.title
 }

--- a/src/main/kotlin/io/github/alexbroadbent/tsgen/config/TimestampFormat.kt
+++ b/src/main/kotlin/io/github/alexbroadbent/tsgen/config/TimestampFormat.kt
@@ -14,8 +14,6 @@ class TimestampFormat(
 
 object TimestampFormatMap {
 
-    val ISO_8601 = TimestampFormat(TimestampFormatTitle.ISO_8601, DateTimeFormatter.ISO_DATE_TIME.addLocaleAndZone())
-
     private val EPOCH_SECONDS_FORMATTER = DateTimeFormatterBuilder()
         .appendValue(ChronoField.INSTANT_SECONDS, 1, 19, SignStyle.NEVER)
         .toFormatter()

--- a/src/main/kotlin/io/github/alexbroadbent/tsgen/config/TimestampGeneratorSettings.kt
+++ b/src/main/kotlin/io/github/alexbroadbent/tsgen/config/TimestampGeneratorSettings.kt
@@ -1,9 +1,8 @@
 package io.github.alexbroadbent.tsgen.config
 
-import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.BaseState
 import com.intellij.openapi.components.SimplePersistentStateComponent
-import com.intellij.openapi.components.ServiceManager
 import com.intellij.openapi.components.State
 import com.intellij.openapi.components.Storage
 import java.time.format.DateTimeFormatter
@@ -22,7 +21,7 @@ class TimestampGeneratorSettings : SimplePersistentStateComponent<TimestampForma
 
     companion object {
         val instance: TimestampGeneratorSettings
-            get() = ServiceManager.getService(TimestampGeneratorSettings::class.java)
+            get() = ApplicationManager.getApplication().getService(TimestampGeneratorSettings::class.java)
     }
 
     var format: TimestampFormat

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -30,6 +30,10 @@
     ]]></description>
 
     <change-notes><![CDATA[
+        <b>Changes in version 1.1.0:</b>
+        <ul>
+            <li>Fix persisting state</li>
+        </ul>
         <b>Changes in version 1.0.1:</b>
         <ul>
             <li>Fix RFC 1123 format</li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -62,7 +62,7 @@
         ]]>
     </change-notes>
 
-    <idea-version since-build="143.0"/>
+    <idea-version since-build="201.0"/>
 
     <depends>com.intellij.modules.lang</depends>
 


### PR DESCRIPTION
The change
- changes serialization of the settings format using `com.intellij.openapi.components.{BaseState, SimplePersistentStateComponent}`
- upgrades platform requires to version 201 (hence no patch-level version update, but 2020.1 is some years old already as well)
- fixes determining the dirty-state of the settings (would probably need to change for something like #8)

resolves #11